### PR TITLE
Bug at 404 custom pages

### DIFF
--- a/dryapp/drydrop_handler.py
+++ b/dryapp/drydrop_handler.py
@@ -140,6 +140,10 @@ class AppHandler(webapp.RequestHandler):
         
         if status_code == 404:
             return False
+        elif request_path == "/404.html":
+            # fixes status for customized not found page
+            logging.debug("Page's /404.html, so i'm changing status code")
+            status_code = 404
 
         self.response.clear()
         for k in self.response.headers.keys():


### PR DESCRIPTION
Hi,

i've found a bug at the custom 404 pages. When returning a 404 page, loaded from /404.html file, it used to return status code 200 instead 404. I've fixed this to return 404. However my bug fix was not so pretty, but solves the problem.

Thanks
