### PR TITLE
Fixed a bug where github was redirecting from http to https, causing urlfetch to fail and cache the failures as files with null contents such that it would not be refetched

### DIFF
--- a/dryapp/drydrop/app/core/vfs.py
+++ b/dryapp/drydrop/app/core/vfs.py
@@ -39,7 +39,8 @@ class VFS(object):
                 log_event("Caching resource <code>%s</code> (%d bytes)" % (path, length))
             logging.debug("VFS: caching resource %s (%d bytes) for %s", path, length, domain)
             resource.domain = domain
-            resource.save()
+            if content!=None:
+              resource.save()
         try:
             length = len(resource.content)
         except:


### PR DESCRIPTION
The changes I made were to have urlfetch follow redirects and to not cache files with null contents.

A more robust error handling mechanism is probably called for which temporarily caches errors with a timeout, but it wasn't necessary to fix this particular bug, so I didn't implement it.
