### PR TITLE
Rakefile bug preventing `rake upload` deployment

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -290,7 +290,9 @@ def patch_main_py()
     end
   end
   File.open(path, "w") do |f|
-    f << lines
+    lines.each do |line|
+      f.puts(line)
+    end
   end
 end
 

--- a/rakefile
+++ b/rakefile
@@ -375,7 +375,9 @@ def patch_app_yaml(version, name)
     end
   end
   File.open(path, "w") do |f|
-    f << lines
+    lines.each do |line|
+      f.puts(line)
+    end
   end
 end
 


### PR DESCRIPTION
I hit a snag in the deployment/installation process on my system (OS X, Ruby 1.9.2p180, Rake 0.9.2) where the patched `app.yaml` wasn't being formatted properly, causing `appcfg.py update` to fail. Instead of writing the patched lines back out individually, the `Rakefile` wrote a string reprentation of the `lines` list:

```
$ cat .deploy/1.7.5.4/app.yaml 
["application: my-project-name\n", "version: master\n", "runtime: python\n", "api_version: 1\n", "\n", "handlers:\n", "- url: .*\n", "  script: 'drydrop_handler.py'"]
```

I'm not well-versed in Ruby (perhaps this is a version-specific issue?), but the attached quick fix seems to do the trick.

Thanks for an awesome app!

_Update:_ Once I got DryDrop deployed, I realized this bug also affects the patching of `drydrop_handler.py`.
